### PR TITLE
docker-composeでEFKを動作させる

### DIFF
--- a/efk/docker-compose.yml
+++ b/efk/docker-compose.yml
@@ -1,0 +1,41 @@
+version: "3"
+services:
+  web:
+    image: httpd
+    ports:
+      - "80:80"
+    links:
+      - fluentd
+    logging:
+      driver: "fluentd"
+      options:
+        fluentd-address: localhost:24224
+        tag: httpd.access
+
+  fluentd:
+    build: ./fluentd
+    volumes:
+      - ./fluentd/conf:/fluentd/etc
+    links:
+      - "elasticsearch"
+    ports:
+      - "24224:24224"
+      - "24224:24224/udp"
+
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.1.2
+    container_name: elasticsearch
+    environment:
+      - "discovery.type=single-node"
+      - xpack.security.enabled=false
+    expose:
+      - "9200"
+    ports:
+      - "9200:9200"
+
+  kibana:
+    image: docker.elastic.co/kibana/kibana:8.1.2
+    links:
+      - "elasticsearch"
+    ports:
+      - "5601:5601"

--- a/efk/fluentd/Dockerfile
+++ b/efk/fluentd/Dockerfile
@@ -1,0 +1,6 @@
+# fluentd/Dockerfile
+
+FROM fluent/fluentd:v1.12.0-debian-1.0
+USER root
+RUN ["gem", "install", "fluent-plugin-elasticsearch", "--no-document", "--version", "5.2.4"]
+USER fluent

--- a/efk/fluentd/conf/fluent.conf
+++ b/efk/fluentd/conf/fluent.conf
@@ -1,0 +1,28 @@
+# fluentd/conf/fluent.conf
+
+<source>
+  @type forward
+  port 24224
+  bind 0.0.0.0
+</source>
+
+<match *.**>
+  @type copy
+
+  <store>
+    @type elasticsearch
+    host elasticsearch
+    port 9200
+    logstash_format true
+    logstash_prefix fluentd
+    logstash_dateformat %Y%m%d
+    include_tag_key true
+    type_name access_log
+    tag_key @log_name
+    flush_interval 1s
+  </store>
+
+  <store>
+    @type stdout
+  </store>
+</match>


### PR DESCRIPTION
以下を参考にelasticsearch+fluentd+kibanaをdocker-composeを使って動かす。
https://docs.fluentd.org/container-deployment/docker-compose

サンプル自体が古くなっている箇所がありコメントに残す。

コンテナを立ち上げた後のステップでアクセスするurlが別のへとリダイレクトして、そこで同じような設定をするとviewが見れた。
https://docs.fluentd.org/container-deployment/docker-compose#step-4-confirm-logs-from-kibana

<img width="1440" alt="image" src="https://user-images.githubusercontent.com/39250854/213188536-640e00de-306b-4510-8af8-9aef9682ef1e.png">

<img width="1440" alt="image" src="https://user-images.githubusercontent.com/39250854/213189132-363c6682-2613-4054-8513-3ea4cac28861.png">

