### PR TITLE
localstackでs3を作成

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
 # fluentd-plugin-sample
+
 fluentd playground to understand how to use its plugins

--- a/s3/docker-compose.yml
+++ b/s3/docker-compose.yml
@@ -1,0 +1,42 @@
+version: "3"
+services:
+  web:
+    image: httpd
+    ports:
+      - "80:80"
+    # links:
+    #   - fluentd
+    # logging:
+    #   driver: "fluentd"
+    #   options:
+    #     fluentd-address: localhost:24224
+    #     tag: httpd.access
+  # fluentd:
+  #   build: ./fluentd
+  #   volumes:
+  #     - ./fluentd/conf:/fluentd/etc
+  #   links:
+  #     - "localstack"
+  #   ports:
+  #     - "24224:24224"
+  #     - "24224:24224/udp"
+  localstack:
+    image: localstack/localstack:1.3.1
+    container_name: "localstack"
+    ports:
+      - 4566:4566
+      - 8000:8000
+    volumes:
+      - ./localstack:/etc/localstack/init/ready.d
+      - /var/run/docker.sock:/var/run/docker.sock
+      - 'localstack-data:/tmp/localstack'
+    environment:
+      - SERVICES=s3
+      - AWS_ACCESS_KEY_ID=test
+      - AWS_SECRET_ACCESS_KEY=test
+      - AWS_DEFAULT_REGION=ap-northeast-1
+      - DISABLE_CORS_CHECKS=1
+
+volumes:
+  localstack-data:
+    driver: 'local'

--- a/s3/localstack/Dockerfile
+++ b/s3/localstack/Dockerfile
@@ -1,0 +1,6 @@
+# fluentd/Dockerfile
+
+FROM fluent/fluentd:v1.12.0-debian-1.0
+USER root
+RUN ["gem", "install", "fluent-plugin-elasticsearch", "--no-document", "--version", "5.2.4"]
+USER fluent

--- a/s3/localstack/s3.sh
+++ b/s3/localstack/s3.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+echo "S3 setup start!"
+echo "Creating S3 bucket..."
+
+aws  --endpoint-url=http://localstack:4566  s3 ls > /tmp/s3buckets.txt
+
+if [ $? -ne 0 ]
+then
+echo -e "date : Error occurs while connecting aws s3.. "
+fi
+
+if grep -q fluentd-logs /tmp/s3buckets.txt; then
+    echo 'bucket exists! fluentd-logs'
+else
+  aws --endpoint-url=http://localstack:4566 s3 mb s3://fluentd-logs/
+  echo 'bucket created!'
+fi
+echo "S3 setup Done!"


### PR DESCRIPTION
flutendとの繋ぎ込みは後にしてs3 bucketの作成だけ。

```
❯ docker-compose up
Starting s3_web_1   ... done
Starting localstack ... done
Attaching to s3_web_1, localstack
web_1         | AH00558: httpd: Could not reliably determine the server's fully qualified domain name, using 192.168.96.2. Set the 'ServerName' directive globally to suppress this message
web_1         | AH00558: httpd: Could not reliably determine the server's fully qualified domain name, using 192.168.96.2. Set the 'ServerName' directive globally to suppress this message
web_1         | [Thu Jan 19 14:18:11.136145 2023] [mpm_event:notice] [pid 1:tid 140405069012288] AH00489: Apache/2.4.55 (Unix) configured -- resuming normal operations
web_1         | [Thu Jan 19 14:18:11.136445 2023] [core:notice] [pid 1:tid 140405069012288] AH00094: Command line: 'httpd -D FOREGROUND'
localstack    | Waiting for all LocalStack services to be ready
localstack    | 2023-01-19 14:18:11,366 CRIT Supervisor is running as root.  Privileges were not dropped because no user is specified in the config file.  If you intend to run as root, you can set user=root in the config file to avoid this message.
localstack    | 2023-01-19 14:18:11,368 INFO supervisord started with pid 14
localstack    | 2023-01-19 14:18:12,373 INFO spawned: 'infra' with pid 19
localstack    | SERVICES variable is ignored if EAGER_SERVICE_LOADING=0.
localstack    | 2023-01-19 14:18:13,758 INFO success: infra entered RUNNING state, process has stayed up for > than 1 seconds (startsecs)
localstack    |
localstack    | LocalStack version: 1.3.1
localstack    | LocalStack Docker container id: 14e41e6fe4d5
localstack    | LocalStack build date: 2022-12-16
localstack    | LocalStack build git hash: 0c095708
localstack    |
localstack    | 2023-01-19T14:18:14.303  WARN --- [-functhread3] hypercorn.error            : ASGI Framework Lifespan error, continuing without Lifespan support
localstack    | 2023-01-19T14:18:14.303  WARN --- [-functhread3] hypercorn.error            : ASGI Framework Lifespan error, continuing without Lifespan support
localstack    | 2023-01-19T14:18:14.305  INFO --- [-functhread3] hypercorn.error            : Running on https://0.0.0.0:4566 (CTRL + C to quit)
localstack    | 2023-01-19T14:18:14.305  INFO --- [-functhread3] hypercorn.error            : Running on https://0.0.0.0:4566 (CTRL + C to quit)
localstack    | Ready.
localstack    | S3 setup start!
localstack    | Creating S3 bucket...
localstack    | 2023-01-19T14:18:15.325  INFO --- [-functhread6] l.services.motoserver      : starting moto server on http://0.0.0.0:55647
localstack    | 2023-01-19T14:18:15.328  INFO --- [   asgi_gw_0] localstack.services.infra  : Starting mock S3 service on http port 4566 ...
localstack    | 2023-01-19T14:18:15.725  INFO --- [   asgi_gw_0] localstack.request.aws     : AWS s3.ListBuckets => 200
localstack    | 2023-01-19T14:18:16.345  INFO --- [   asgi_gw_0] localstack.request.aws     : AWS s3.CreateBucket => 200
localstack    | make_bucket: fluentd-logs
localstack    | bucket created!
localstack    | S3 setup Done!

```

が、動作確認のためのコマンドが通らない

```

❯ awslocal
Traceback (most recent call last):
  File "/usr/local/bin/awslocal", line 34, in <module>
    from localstack_client import config  # noqa: E402
  File "/usr/local/lib/python2.7/site-packages/localstack_client/config.py", line 124
    _service_endpoints_template[key] = f"{value.rpartition(':')[0]}:{EDGE_PORT}"
                                                                               ^
SyntaxError: invalid syntax

```